### PR TITLE
Adjust assist label offsets

### DIFF
--- a/src/layouts/ja_10key_flick/AssistLabel.qml
+++ b/src/layouts/ja_10key_flick/AssistLabel.qml
@@ -4,7 +4,7 @@ import com.jolla.keyboard 1.0
 
 Text {
     property int keyIndex
-    
+    property real offset: (parent.width - Theme.paddingMedium * 1.5) / 3
     visible: portraitMode && !pressed
     horizontalAlignment: Text.AlignHCenter
     verticalAlignment: Text.AlignVCenter
@@ -14,13 +14,13 @@ Text {
         horizontalCenterOffset: keyIndex == 2 || keyIndex == 4
             ? 0
             : (keyIndex == 1
-                ? -Theme.fontSizeSmall
-                : Theme.fontSizeSmall)
+                ? -offset
+                : offset)
         verticalCenterOffset: keyIndex == 1 || keyIndex == 3
             ? 0
             : (keyIndex == 2
-                ? -Theme.fontSizeSmall
-                : Theme.fontSizeSmall)
+                ? -offset
+                : offset)
     }
     font.family: Theme.fontFamily
     font.pixelSize: !portraitMode && attributes.isShifted

--- a/src/layouts/ja_10key_flick/AssistLabel.qml
+++ b/src/layouts/ja_10key_flick/AssistLabel.qml
@@ -14,13 +14,13 @@ Text {
         horizontalCenterOffset: keyIndex == 2 || keyIndex == 4
             ? 0
             : (keyIndex == 1
-                ? -Theme.paddingMedium * 3
-                : Theme.paddingMedium * 3)
+                ? -Theme.fontSizeSmall
+                : Theme.fontSizeSmall)
         verticalCenterOffset: keyIndex == 1 || keyIndex == 3
             ? 0
             : (keyIndex == 2
-                ? -Theme.paddingMedium * 3
-                : Theme.paddingMedium * 3)
+                ? -Theme.fontSizeSmall
+                : Theme.fontSizeSmall)
     }
     font.family: Theme.fontFamily
     font.pixelSize: !portraitMode && attributes.isShifted

--- a/src/layouts/ja_10key_flick/TenKey_Flick.qml
+++ b/src/layouts/ja_10key_flick/TenKey_Flick.qml
@@ -106,9 +106,9 @@ KeyBase {
                         : (!portraitMode
                             ? ((attributes.isShifted && !attributes.inSymView) || symbolOnly
                                 ? currentText
-                                : currentText.charAt(flickerIndex))                                
+                                : currentText.charAt(flickerIndex))
                             : currentText.charAt(0))))
-                            
+
         }
         Text {
             id: secondaryLabel
@@ -129,7 +129,7 @@ KeyBase {
                     : "")
         }
     }
-    
+
     Repeater {
         model: 4
         AssistLabel {


### PR DESCRIPTION
Use Theme.fontSize* instead of Theme.padding*

Before:
![screenshot_20181201_001](https://user-images.githubusercontent.com/9744580/50373495-44d5e000-0623-11e9-8788-2c85542b9333.jpg)

After:
![screenshot_20181222_001](https://user-images.githubusercontent.com/9744580/50373497-4acbc100-0623-11e9-944c-2251b7062b4b.jpg)
